### PR TITLE
Remove the need for sh dep

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,3 @@
-{deps_dir, ["../../deps"]}.
-{deps, [{sh, ".*", {git, "git://github.com/synrc/sh", {tag,"master"}}}]}.
-
 {port_env,
  [{"darwin", "LDFLAGS", "-framework CoreFoundation -framework CoreServices"},
   {"darwin", "CC", "clang"},

--- a/src/sys/inotifywait.erl
+++ b/src/sys/inotifywait.erl
@@ -7,8 +7,9 @@ known_events() -> [renamed, closed, modified, isdir, undefined].
 
 start_port(Path, Cwd) ->
     Path1 = filename:absname(Path),
-    Args = [find_executable(), "-m", "-e", "close_write", "-e", "moved_to", "-e", "create", "-r", Path1],
-    erlang:open_port({spawn_executable, sh:fdlink_executable()},
+    Args = ["-c", "inotifywait $0 $@ & PID=$!; read a; kill $PID",
+            "-m", "-e", "close_write", "-e", "moved_to", "-e", "create", "-r", Path1],
+    erlang:open_port({spawn_executable, os:find_executable("sh")},
         [stream, exit_status, {line, 16384}, {args, Args}, {cd, Cwd}]).
 
 line_to_event(Line) ->


### PR DESCRIPTION
We remove the need for the sh dependency by running Linux commands inside `sh -c` and using a short shell script to detect the stdin being closed and kill the child process.
