### PR TITLE
Add package.exs

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -1,0 +1,16 @@
+defmodule FS.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :fs,
+     version: "0.9.0",
+     description: "Erlang FileSystem Listener",
+     package: package]
+  end
+
+  defp package do
+    [files: ~w(c_src include priv src LICENSE package.exs README.md rebar.config),
+     licenses: ["MIT"],
+     links: %{"GitHub" => "https://github.com/synrc/fs"}]
+   end
+end


### PR DESCRIPTION
Folks, this is a pull request that adds a package.exs file
so the package can be published to hex.

We are planning to use it as a Phoenix dependency [in the
upcoming release](https://github.com/phoenixframework/phoenix/pull/723) so if you could
merge this PR and publish the package, we would really appreciate it.

Note we cannot add a mix.exs because we want the package to
be treated as a rebar depndency in order to compile the
c sources.

Publishing the package can be done with:

```
MIX_ENV=package.exs mix hex.publish
```

Let me know if you have any questions and thanks! :heart:
