### PR TITLE
Use semantic versioning

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -3,7 +3,7 @@ defmodule FS.Mixfile do
 
   def project do
     [app: :fs,
-     version: "0.9.0",
+     version: "0.9.1",
      description: "Erlang FileSystem Listener",
      package: package]
   end

--- a/src/fs.app.src
+++ b/src/fs.app.src
@@ -1,6 +1,6 @@
 {application, fs, 
  [{description, "VXZ FS Listener"},
-  {vsn, "0.9"},
+  {vsn, "0.9.1"},
   {registered, []},
   {applications, [kernel,stdlib]},
   {mod, { fs_app, []}},


### PR DESCRIPTION
`MIX_EXS=package.exs mix hex.publish` should also work now.
