### PR TITLE
initial approach to have possibility to start own supervisor for diff...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 deps/
+priv/mac_listener
+*.d
+*.o
+.rebar
+ebin/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ NOTE: On Linux you need to install inotify-tools.
 ### Subscribe to Notifications
 
 ```erlang
-> fs:subscribe(). % the pid will receive events as messages
+> fs:start_link(fs_watcher, "/Users/5HT/synrc/fs"). % need to start the fs watcher
+> fs:subscribe(fs_watcher). % the pid will receive events as messages
 > flush(). 
 Shell got {<0.47.0>,
            {fs,file_event},
@@ -23,7 +24,7 @@ Shell got {<0.47.0>,
 ### List Events from Backend
 
 ```erlang
-> fs:known_events(). % returns events known by your current backend
+> fs:known_events(fs_watcher). % returns events known by your current backend
 [mustscansubdirs,userdropped,kerneldropped,eventidswrapped,
  historydone,rootchanged,mount,unmount,created,removed,
  inodemetamod,renamed,modified,finderinfomod,changeowner,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NOTE: On Linux you need to install inotify-tools.
 ```erlang
 > fs:start_link(fs_watcher, "/Users/5HT/synrc/fs"). % need to start the fs watcher
 > fs:subscribe(fs_watcher). % the pid will receive events as messages
-> flush(). 
+> flush().
 Shell got {<0.47.0>,
            {fs,file_event},
            {"/Users/5HT/synrc/fs/src/README.md",[closed,modified]}}
@@ -38,6 +38,27 @@ Shell got {<0.47.0>,
 =INFO REPORT==== 28-Aug-2013::19:36:26 ===
 file_event: "/tank/proger/erlfsmon/src/4913" [closed,modified]
 ```
+
+### API compatibility
+
+API is per default compatible to version before 1.10.
+
+By application start, `fs` will start fs watcher on specified per enviroment `path` or
+if enviroment is unsetted, than in `CWD`.
+
+That means you can still use it, like:
+
+```erlang
+fs:subscribe()
+```
+
+If you do not want to use backwards_compatible mode, disable it by setting `fs` enviroment:
+
+```
+{backwards_compatible, false}
+```
+
+This option will lead, that default fs watcher willn't be started.
 
 Credits
 -------

--- a/src/fs.app.src
+++ b/src/fs.app.src
@@ -4,4 +4,6 @@
   {registered, []},
   {applications, [kernel,stdlib]},
   {mod, { fs_app, []}},
-  {env, []}]}.
+  {env, [
+      {backwards_compatible, true}
+  ]}]}.

--- a/src/fs.erl
+++ b/src/fs.erl
@@ -1,8 +1,11 @@
 -module(fs).
 -include_lib("kernel/include/file.hrl").
--export([subscribe/0, known_events/0, start_looper/0, path/0, find_executable/2]).
+-export([start_link/4, subscribe/1, known_events/0, start_looper/0, path/0, find_executable/2]).
 
 % sample subscriber
+
+start_link(SupName, EventHandler, FileHandler, Path) -> fs_sup:start_link(SupName, EventHandler, FileHandler, Path).
+subscribe(Name) -> gen_event:add_sup_handler(Name, {fs_event_bridge, self()}, [self()]).
 
 subscribe() -> gen_event:add_sup_handler(fs_events, {fs_event_bridge, self()}, [self()]).
 known_events() -> gen_server:call(fs_server, known_events).

--- a/src/fs.erl
+++ b/src/fs.erl
@@ -1,16 +1,28 @@
 -module(fs).
 -include_lib("kernel/include/file.hrl").
--export([start_link/2, subscribe/1, known_events/1, start_looper/1, find_executable/2]).
+-export([start_link/1, start_link/2, subscribe/0, subscribe/1, known_events/0, known_events/1,
+         start_looper/0, start_looper/1, find_executable/2]).
 
 % sample subscriber
 
+start_link(Name) -> start_link(Name, default_path()).
 start_link(Name, Path) ->
     SupName = name(Name, "sup"),
     FileHandler = name(Name, "file"),
     fs_sup:start_link(SupName, Name, FileHandler, Path).
+
+subscribe() -> subscribe(default_fs).
 subscribe(Name) -> gen_event:add_sup_handler(Name, {fs_event_bridge, self()}, [self()]).
 
+default_path() ->
+    case application:get_env(fs, path) of
+        {ok, P} -> filename:absname(P);
+        undefined -> filename:absname("") end.
+
+known_events() -> known_events(default_fs).
 known_events(Name) -> gen_server:call(name(Name, "file"), known_events).
+
+start_looper() -> start_looper(default_fs).
 start_looper(Name) -> spawn(fun() -> subscribe(Name), loop() end).
 
 loop() ->

--- a/src/fs_app.erl
+++ b/src/fs_app.erl
@@ -2,5 +2,8 @@
 -behaviour(application).
 -export([start/2, stop/1]).
 
-start(_StartType, _StartArgs) -> {ok, self()}.
+start(_StartType, _StartArgs) ->
+    case application:get_env(fs, backwards_compatible) of
+        {ok, false} -> {ok, self()};
+        {ok, true} -> fs:start_link(default_fs) end.
 stop(_State) -> ok.

--- a/src/fs_app.erl
+++ b/src/fs_app.erl
@@ -2,5 +2,5 @@
 -behaviour(application).
 -export([start/2, stop/1]).
 
-start(_StartType, _StartArgs) -> fs_sup:start_link().
+start(_StartType, _StartArgs) -> {ok, self()}.
 stop(_State) -> ok.

--- a/src/fs_server.erl
+++ b/src/fs_server.erl
@@ -1,21 +1,21 @@
 -module(fs_server).
 -behaviour(gen_server).
 -define(SERVER, ?MODULE).
--export([start_link/3]).
+-export([start_link/5]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,terminate/2, code_change/3]).
 
--record(state, {port, path, backend}).
+-record(state, {event_handler, port, path, backend}).
 
-notify(file_event = A, Msg) -> Key = {fs, A}, gen_event:notify(fs_events, {self(), Key, Msg}).
-start_link(Backend, Path, Cwd) -> gen_server:start_link({local, ?SERVER}, ?MODULE, [Backend, Path, Cwd], []).
-init([Backend, Path, Cwd]) -> {ok, #state{port=Backend:start_port(Path, Cwd),path=Path,backend=Backend}}.
+notify(EventHandler, file_event = A, Msg) -> Key = {fs, A}, gen_event:notify(EventHandler, {self(), Key, Msg}).
+start_link(Name, EventHandler, Backend, Path, Cwd) -> gen_server:start_link({local, Name}, ?MODULE, [EventHandler, Backend, Path, Cwd], []).
+init([EventHandler, Backend, Path, Cwd]) -> {ok, #state{event_handler=EventHandler,port=Backend:start_port(Path, Cwd),path=Path,backend=Backend}}.
 
 handle_call(known_events, _From, #state{backend=Backend} = State) -> {reply, Backend:known_events(), State};
 handle_call(_Request, _From, State) -> {reply, ok, State}.
 handle_cast(_Msg, State) -> {noreply, State}.
-handle_info({_Port, {data, {eol, Line}}}, #state{backend=Backend} = State) ->
+handle_info({_Port, {data, {eol, Line}}}, #state{event_handler=EventHandler,backend=Backend} = State) ->
     Event = Backend:line_to_event(Line),
-    notify(file_event, Event),
+    notify(EventHandler, file_event, Event),
     {noreply, State};
 handle_info({_Port, {data, {noeol, Line}}}, State) ->
     error_logger:error_msg("~p line too long: ~p, ignoring~n", [?SERVER, Line]),


### PR DESCRIPTION
…erent handlers

It is not thought for merge, but the question, why the interface is so inflexible? If you want to change the path, you need to set environment, before starting the fs application (that leads, that on all places, where library is used, developers simply subscribe to cwd, which is default and checking the needed pattern for the path). And, it is not possible to create more, than one.

I think, there should be interface for it, for creating supervisors in own tree.

Simple attemp to add interface with start_link/4 (which get 3 names and path and it is still ugly), but want to try, that it works.

2 changes, which I want to reach:
- possibility to specify directory directly
- start more, that one handler

What do you think about it in general?
