### PR TITLE
fixes, in windows, event flag "MOVE" to correct "MOVED_TO"

### DIFF
--- a/src/sys/inotifywait_win32.erl
+++ b/src/sys/inotifywait_win32.erl
@@ -23,7 +23,7 @@ line_to_event(Line) ->
 convert_flag("CREATE") -> created;
 convert_flag("MODIFY") -> modified;
 convert_flag("DELETE") -> removed;
-convert_flag("MOVE") -> renamed;
+convert_flag("MOVED_TO") -> renamed;
 convert_flag(_) -> undefined.
 
 re() ->


### PR DESCRIPTION
In windows, the "inotifywait.exe" fires a "MOVED_TO" event flag, not a "MOVE" one.
If this is fixed in "inotifywait_win32.erl" then the events chain, when a file is modified, is correctly sent to active gen_server and with another minor addition in active.erl (so that active gen_server doesn't crash in the middle of a file modification's events chain transmission) the windows sync code issue is fixed.
