### PR TITLE
Add rebar3 support, prepare for hex publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ priv/mac_listener
 *.o
 .rebar
 ebin/
+_build/
+rebar.lock

--- a/rebar.config
+++ b/rebar.config
@@ -12,6 +12,13 @@
   {"freebsd", "priv/kqueue", ["c_src/bsd/*.c"]}
   ]}.
 
+{plugins, [pc, rebar3_hex]}.
+{provider_hooks, [
+    {pre, [
+        {compile, {pc, compile}},
+        {clean,   {pc, clean}}
+    ]}
+]}.
 %{pre_hooks, [
 %             {"win32",  compile, "make -f c_src/windows/Makefile"},
 %             {"win32",  clean,   "make -f c_src/windows/Makefile clean"}

--- a/src/fs.app.src
+++ b/src/fs.app.src
@@ -1,9 +1,13 @@
 {application, fs,
  [{description, "FS VXZ Listener"},
-  {vsn, "1.9"},
+  {vsn, "1.10"},
   {registered, []},
   {applications, [kernel,stdlib]},
   {mod, { fs_app, []}},
   {env, [
       {backwards_compatible, true}
-  ]}]}.
+  ]},
+  {maintainers,["Maxim Sokhatsky", "Vladimir Kirillov"]},
+  {licenses, ["ISCL"]},
+  {links,[{"Github","https://github.com/synrc/fs"}]}
+  ]}.


### PR DESCRIPTION
Update to a new version as between 1.9 and publishing
there are different changes happen.

This pull request provides changes for compiling with rebar3 (it doesn't break rebar 2 compiling), with adding rebar pc (port compiler) plugin and rebar3_hex plugin, which is needed for publishing.

For publishing on hex with `rebar3`:

``` bash
rebar3 clean
rebar3 hex publish
```

Related issues: #20 and #24 
