### PR TITLE
Added support for ATTRIB event in inotifywait

### DIFF
--- a/src/sys/inotifywait.erl
+++ b/src/sys/inotifywait.erl
@@ -3,12 +3,12 @@
 -export(?API).
 
 find_executable() -> os:find_executable("inotifywait").
-known_events() -> [created, deleted, renamed, closed, modified, isdir, undefined].
+known_events() -> [created, deleted, renamed, closed, modified, isdir, attribute, undefined].
 
 start_port(Path, Cwd) ->
     Path1 = filename:absname(Path),
     Args = ["-c", "inotifywait $0 $@ & PID=$!; read a; kill $PID",
-            "-m", "-e", "close_write", "-e", "moved_to", "-e", "create", "-e", "delete", "-r", Path1],
+            "-m", "-e", "close_write", "-e", "moved_to", "-e", "create", "-e", "delete", "-e", "attrib", "-r", Path1],
     erlang:open_port({spawn_executable, os:find_executable("sh")},
         [stream, exit_status, {line, 16384}, {args, Args}, {cd, Cwd}]).
 
@@ -24,6 +24,7 @@ convert_flag("ISDIR") -> isdir;
 convert_flag("CLOSE_WRITE") -> modified;
 convert_flag("CLOSE") -> closed;
 convert_flag("MOVED_TO") -> renamed;
+convert_flag("ATTRIB") -> attribute;
 convert_flag(_) -> undefined.
 
 re() ->


### PR DESCRIPTION
If you use Vagrant, you can use https://github.com/mhallin/vagrant-notify-forwarder to send notifications from the host to the guest. However, it sends all changes only as ATTRIB changes, as per mhallin/notify-forwarder#2.

This change allows the usage of something like mix_test_watch inside of a vagrant dev box.
