### PR TITLE
Fix unexpected exit when call in escript on macOS

### DIFF
--- a/src/fs.erl
+++ b/src/fs.erl
@@ -38,7 +38,7 @@ find_executable(Cmd, DepsPath) ->
 
 mad_file(DepsPath) ->
     case filelib:is_regular(DepsPath) of
-    true  -> DepsPath;
+    true  -> path() ++ "/" ++ DepsPath;
     false ->
         case mad_repl:load_file(DepsPath) of
         {error,_} ->


### PR DESCRIPTION
Because, fsevent_fetch use relative path. It can not resolve from `{cd, Cwd}`.
So, it sould be absolute path or remove cd part from [here](https://github.com/synrc/fs/blob/master/src/sys/fsevents.erl#L15).

It will be happen only macOS. because, It is only one that use relative path.

```
13:18:58.897 [error] GenServer :watcherfile terminating
** (stop) {:port_exit, 2}
Last message: {#Port<0.3106>, {:exit_status, 2}}
State: {:state, :watcher, #Port<0.3106>, "/Users/user_name/Documents/test-project/", :fsevents}
```