### PR TITLE
Remove rebar3_hex plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
   {"freebsd", "priv/kqueue", ["c_src/bsd/*.c"]}
   ]}.
 
-{plugins, [pc, rebar3_hex]}.
+{plugins, [pc]}.
 {provider_hooks, [
     {pre, [
         {compile, {pc, compile}},


### PR DESCRIPTION
The rebar3_hex plugin should be installed globally instead of for each project. Otherwise it will be downloaded by everyone consuming your project even though the plugin is only used to publish packages.