### PR TITLE
Update fs_sup.erl

### DIFF
--- a/src/fs_sup.erl
+++ b/src/fs_sup.erl
@@ -29,7 +29,7 @@ has_executable(Backend) ->
         _     -> true end.
 
 os_not_supported() ->
-    error_logger:error_msg("fs does not support the current operating system~n",[]).
+    error_logger:warning_msg("fs does not support the current operating system: auto-reloading might not work~n",[]).
 
 backend_port_not_found(Backend) ->
     error_logger:error_msg("backend port not found: ~p~n",[Backend]).


### PR DESCRIPTION
changed the missing-support message to be a warning. added more information. see https://github.com/synrc/fs/issues/17