### PR TITLE
Fix open_port/2 call for kqueue backend

### DIFF
--- a/src/sys/kqueue.erl
+++ b/src/sys/kqueue.erl
@@ -9,4 +9,4 @@ line_to_event(Line) ->
 find_executable() -> fs:find_executable("kqueue", "deps/fs/priv/kqueue").
 start_port(Path, Cwd) ->
     erlang:open_port({spawn_executable, find_executable()},
-        [stream, exit_status, {line, 16384}, {args, Path}, {cd, Cwd}]).
+        [stream, exit_status, {line, 16384}, {args, [Path]}, {cd, Cwd}]).


### PR DESCRIPTION
The port command arguments must be specified as a list.