### PR TITLE
kqueue backend: fix kqueue event flags

### DIFF
--- a/c_src/bsd/main.c
+++ b/c_src/bsd/main.c
@@ -11,12 +11,9 @@ int main(int argc, char *argv[]) {
     int fd, kq, nev;
     if ((fd = open(argv[1], O_RDONLY)) == -1) return 1;
     EV_SET(&change, fd, EVFILT_VNODE , EV_ADD
-                                     | EV_ENABLE
-                                     | EV_DISABLE
                                      | EV_CLEAR
                                      | EV_DELETE
                                      | EV_EOF
-                                     | EV_RECEIPT
                                      | EV_DISPATCH
                                      | EV_ONESHOT,
                                        NOTE_DELETE


### PR DESCRIPTION
 - EV_ENABLE, and EV_DISABLE are mutually exclusive[1]
 - EV_RECEIPT causes kevent(2) to be returned immediately with
   EV_ERROR as status, which doesn't seem to be the intent of the
   invocation.

[1] http://fxr.watson.org/fxr/source/kern/kern_event.c#L1157