### PR TITLE
Return not supported on SunOS

### DIFF
--- a/src/fs_sup.erl
+++ b/src/fs_sup.erl
@@ -10,6 +10,7 @@ init([EventHandler, FileHandler, Path]) ->
     Backend = case os:type() of
         {unix, darwin} -> fsevents;
         {unix, linux} -> inotifywait;
+        {unix, sunos} -> undefined;
         {unix, _} -> kqueue;
         {win32, nt} -> inotifywait_win32;
         _ -> undefined end,


### PR DESCRIPTION
The current os:type() catch attempts to access kqueue on SunOS platforms, which doesn't exist of course. This commit makes it return undefined properly.

Remotely related to synrc/fs#17, as in having some kind of backend supported on SunOS would be nice.