### PR TITLE
Fixing events of unicode filenames

### DIFF
--- a/src/sys/fsevents.erl
+++ b/src/sys/fsevents.erl
@@ -12,9 +12,10 @@ known_events() ->
 
 start_port(Path, Cwd) ->
     erlang:open_port({spawn_executable, find_executable()},
-        [stream, exit_status, {line, 16384}, {args, ["-F", Path]}, {cd, Cwd}]).
+        [stream, exit_status, binary, {line, 16384}, {args, ["-F", Path]}, {cd, Cwd}]).
 
-line_to_event(Line) ->
+line_to_event(Line0) ->
+    Line = unicode:characters_to_list(Line0, utf8),   
     [_EventId, Flags1, Path] = string:tokens(Line, [$\t]),
     [_, Flags2] = string:tokens(Flags1, [$=]),
     {ok, T, _} = erl_scan:string(Flags2 ++ "."),

--- a/src/sys/inotifywait.erl
+++ b/src/sys/inotifywait.erl
@@ -11,9 +11,10 @@ start_port(Path, Cwd) ->
             "-m", "-e", "modify", "-e", "close_write", "-e", "moved_to", "-e", "create", "-e", "delete",
             "-e", "attrib", "--quiet", "-r", Path1],
     erlang:open_port({spawn_executable, os:find_executable("sh")},
-        [stream, exit_status, {line, 16384}, {args, Args}, {cd, Cwd}]).
+        [stream, exit_status, binary, {line, 16384}, {args, Args}, {cd, Cwd}]).
 
-line_to_event(Line) ->
+line_to_event(Line0) ->
+    Line = unicode:characters_to_list(Line0, utf8),   
     {match, [Dir, Flags1, DirEntry]} = re:run(Line, re(), [{capture, all_but_first, list}]),
     Flags = [convert_flag(F) || F <- string:tokens(Flags1, ",")],
     Path = Dir ++ DirEntry,


### PR DESCRIPTION
Hi this attached two patches fixes handling of unicode filenames in linux and macos. Both systems use by default utf8 and hence this fix will work for most environments.

Before this patch unicode names would be distorted after the use of the regular pattern match. You can easily try with a filename such as `臺灣.txt` Put it into a directory and trigger the change with `touch 臺灣.txt`

For windows I've no idea how to fetch the current system environment encoding -- or how filenames are being encoded at all -- Have no machine handy atm. So might look into windows later.