### PR TITLE
Fix Incorrect Version Error When Used with Mac OS 11 or Greater

### DIFF
--- a/c_src/mac/main.c
+++ b/c_src/mac/main.c
@@ -1,5 +1,8 @@
 #include "common.h"
 #include "cli.h"
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <stdio.h>
 
 // TODO: set on fire. cli.{h,c} handle both parsing and defaults, so there's
 //       no need to set those here. also, in order to scope metadata by path,
@@ -49,12 +52,14 @@ static void append_path(const char* path)
 static inline void parse_cli_settings(int argc, const char* argv[])
 {
   // runtime os version detection
-  SInt32 osMajorVersion, osMinorVersion;
-  if (!(Gestalt(gestaltSystemVersionMajor, &osMajorVersion) == noErr)) {
-    osMajorVersion = 0;
-  }
-  if (!(Gestalt(gestaltSystemVersionMinor, &osMinorVersion) == noErr)) {
-    osMinorVersion = 0;
+  char buf[25];
+  size_t buflen = 25;
+  sysctlbyname("kern.osproductversion", &buf, &buflen, NULL, 0);
+  int osMajorVersion, osMinorVersion;
+  int res = sscanf(buf, "%d.%d", &osMajorVersion, &osMinorVersion);
+  if (res != 2)
+  {
+    osMajorVersion = osMinorVersion = 0;
   }
 
   if ((osMajorVersion == 10) & (osMinorVersion < 5)) {


### PR DESCRIPTION
Gestalt Manager is considered deprecated [https://developer.apple.com/documentation/coreservices/carbon_core/gestalt_manager?language=objc](https://developer.apple.com/documentation/coreservices/carbon_core/gestalt_manager?language=objc) and an incorrect error is thrown when using this package with Mac OS 11
"MacOSX 10.7 or later required for --file-events"