### PR TITLE
Log error, but don't crash when backend is not working

### DIFF
--- a/src/fs_server.erl
+++ b/src/fs_server.erl
@@ -4,11 +4,11 @@
 -export([start_link/5]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,terminate/2, code_change/3]).
 
--record(state, {event_handler, port, path, backend}).
+-record(state, {event_handler, port, path, backend, cwd, crashes}).
 
 notify(EventHandler, file_event = A, Msg) -> Key = {fs, A}, gen_event:notify(EventHandler, {self(), Key, Msg}).
 start_link(Name, EventHandler, Backend, Path, Cwd) -> gen_server:start_link({local, Name}, ?MODULE, [EventHandler, Backend, Path, Cwd], []).
-init([EventHandler, Backend, Path, Cwd]) -> {ok, #state{event_handler=EventHandler,port=Backend:start_port(Path, Cwd),path=Path,backend=Backend}}.
+init([EventHandler, Backend, Path, Cwd]) -> {ok, #state{event_handler=EventHandler,port=Backend:start_port(Path, Cwd),path=Path,backend=Backend,cwd=Cwd,crashes=0}}.
 
 handle_call(known_events, _From, #state{backend=Backend} = State) -> {reply, Backend:known_events(), State};
 handle_call(_Request, _From, State) -> {reply, ok, State}.
@@ -20,7 +20,10 @@ handle_info({_Port, {data, {eol, Line}}}, #state{event_handler=EventHandler,back
 handle_info({_Port, {data, {noeol, Line}}}, State) ->
     error_logger:error_msg("~p line too long: ~p, ignoring~n", [?SERVER, Line]),
     {noreply, State};
-handle_info({_Port, {exit_status, Status}}, State) -> {stop, {port_exit, Status}, State};
+handle_info({_Port, {exit_status, Status}}, #state{path=Path,backend=Backend,cwd=Cwd,crashes=Crashes} = State) ->
+    error_logger:error_msg("~p port_exit ~p, retry ~p~n", [?SERVER, Status, Crashes]),
+    timer:sleep(100*(Crashes+1)*(Crashes+1)),
+    {noreply, State#state{port=Backend:start_port(Path, Cwd),crashes=Crashes+1}};
 handle_info(_Info, State) -> {noreply, State}.
 terminate(_Reason, #state{port=Port}) -> (catch port_close(Port)), ok.
 code_change(_OldVsn, State, _Extra) -> {ok, State}.


### PR DESCRIPTION
I've got an application that is deployed on many different machines and architectures. I would like to ensure that when the file monitoring tool is not working correctly (e.g. it crashes) then that is not bringing down the whole app. This change just tries to restart the file monitoring backend with an exponential back-off in those cases.

But I'm not sure if this is breaking other use cases? Also, I was thinking to add a fallback polling fs backend in this case (e.g. after 5 attempts to restart the backend), but that seems like it should require configuration?

Anyway, let me know if you have any thoughts on this.

