### PR TITLE
Update pc -> 1.15.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
   {"freebsd", "priv/kqueue", ["c_src/bsd/*.c"]}
   ]}.
 
-{plugins, [pc, rebar3_hex]}.
+{plugins, [{pc, "1.15.0"}]}.
 {provider_hooks, [
     {pre, [
         {compile, {pc, compile}},


### PR DESCRIPTION
Compiling that lib using `rebar 3.23.0 on Erlang/OTP 27 Erts 15.0` results on the error below:

```sh
===> Analyzing applications...
===> Compiling fs
===> compile options: {erl_opts, [debug_info]}.
===> files to analyze ["/home/nclaud/projects/elixir/test_fs/deps/fs/src/fs_event_bridge.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/fs_sup.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/sys/inotifywait_win32.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/sys/inotifywait.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/sys/fsevents.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/sys/kqueue.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/fs.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/fs_app.erl",
                       "/home/nclaud/projects/elixir/test_fs/deps/fs/src/fs_server.erl"]
===> Compiling _build/default/plugins/pc/src/pc_port_env.erl failed
_build/default/plugins/pc/src/pc_port_env.erl:190:10: code:lib_dir/2 is deprecated; this functionality will be removed in a future release
```

Updating pc solves the issue