### PR TITLE
ci: update otp and elixir version

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -7,8 +7,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: erlef/setup-elixir@v1
       with:
-        otp-version: 23.x
-        elixir-version: 1.9.x
+        otp-version: '26'
+        elixir-version: 1.16.x
     - name: Dependencies
       run: |
         mix local.rebar --force


### PR DESCRIPTION
Sorry, I didn't notice that the CI was failing on my last PR.
- #73

Update to the latest Elixir/Erlang version (OTP 27 is not officially supported on Elixir 1.16 atm). 

