### PR TITLE
Use inotifywait for {Free,Open}BSD

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,9 +10,7 @@
 {hex, [{doc, edoc}]}.
 
 {port_specs,
- [{"darwin", "priv/mac_listener", ["c_src/mac/*.c"]},
-  {"freebsd", "priv/kqueue", ["c_src/bsd/*.c"]}
-  ]}.
+ [{"darwin", "priv/mac_listener", ["c_src/mac/*.c"]}]}.
 
 {plugins, [{pc, "1.15.0"}]}.
 {provider_hooks, [

--- a/src/fs_sup.erl
+++ b/src/fs_sup.erl
@@ -18,6 +18,8 @@ init([EventHandler, FileHandler, Path]) ->
     Backend = case os:type() of
                   {unix, darwin} -> fsevents;
                   {unix, linux} -> inotifywait;
+                  {unix, freebsd} -> inotifywait;
+                  {unix, openbsd} -> inotifywait;
                   {unix, sunos} -> undefined;
                   {unix, _} -> kqueue;
                   {win32, nt} -> inotifywait_win32;


### PR DESCRIPTION
kqueue definitely does not work on OpenBSD and according to https://github.com/5HT/fs/issues/21 and https://github.com/5HT/fs/issues/17 it doesn't work on FreeBSD either.

I propose to use inotifywait which is available as a port on both systems instead.